### PR TITLE
Allow CORS credentials on preflight

### DIFF
--- a/cmd/media-proxy/main.go
+++ b/cmd/media-proxy/main.go
@@ -77,13 +77,7 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	corsHandler := cors.New(cors.Options{
-		AllowedOrigins: []string{cfg.CORSAllowedOrigin},
-		AllowedMethods: []string{http.MethodGet, http.MethodOptions},
-		AllowedHeaders: []string{"Authorization", "Range"},
-		ExposedHeaders: []string{"Content-Type", "Content-Range", "Accept-Ranges", "Content-Disposition", "Content-Length"},
-		MaxAge:         86400,
-	}).Handler(mux)
+	corsHandler := newCORSHandler(cfg, mux)
 
 	server := &http.Server{
 		Addr:              cfg.ListenAddr,
@@ -94,4 +88,15 @@ func main() {
 	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
 		log.Printf("server error: %v", err)
 	}
+}
+
+func newCORSHandler(cfg config.Config, handler http.Handler) http.Handler {
+	return cors.New(cors.Options{
+		AllowedOrigins:   []string{cfg.CORSAllowedOrigin},
+		AllowedMethods:   []string{http.MethodGet, http.MethodOptions},
+		AllowedHeaders:   []string{"Authorization", "Range"},
+		ExposedHeaders:   []string{"Content-Type", "Content-Range", "Accept-Ranges", "Content-Disposition", "Content-Length"},
+		AllowCredentials: true,
+		MaxAge:           86400,
+	}).Handler(handler)
 }

--- a/cmd/media-proxy/main_test.go
+++ b/cmd/media-proxy/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agynio/media-proxy/internal/config"
+)
+
+func TestCORSPreflightAllowsCredentials(t *testing.T) {
+	cfg := config.Config{CORSAllowedOrigin: "https://example.test"}
+	handler := newCORSHandler(cfg, http.NewServeMux())
+
+	req := httptest.NewRequest(http.MethodOptions, "/proxy", nil)
+	req.Header.Set("Origin", cfg.CORSAllowedOrigin)
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	recorder := httptest.NewRecorder()
+	handler.ServeHTTP(recorder, req)
+	resp := recorder.Result()
+	if err := resp.Body.Close(); err != nil {
+		t.Fatalf("failed to close response body: %v", err)
+	}
+
+	if value := resp.Header.Get("Access-Control-Allow-Credentials"); value != "true" {
+		t.Fatalf("expected Access-Control-Allow-Credentials true, got %q", value)
+	}
+}

--- a/internal/auth/resolver.go
+++ b/internal/auth/resolver.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -79,7 +80,7 @@ func (r *Resolver) ResolveFromToken(ctx context.Context, accessToken string) (id
 	return identityFromUser(createResponse.GetUser())
 }
 
-func (r *Resolver) fetchUserInfo(ctx context.Context, accessToken, expectedSub string) (*oidc.UserInfo, error) {
+func (r *Resolver) fetchUserInfo(ctx context.Context, accessToken, expectedSub string) (_ *oidc.UserInfo, err error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, r.userinfoEndpoint, nil)
 	if err != nil {
 		return nil, err
@@ -90,7 +91,15 @@ func (r *Resolver) fetchUserInfo(ctx context.Context, accessToken, expectedSub s
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			if err == nil {
+				err = closeErr
+				return
+			}
+			err = errors.Join(err, closeErr)
+		}
+	}()
 
 	const maxUserInfoResponseBytes = 1 << 20
 	limitedBody := io.LimitReader(resp.Body, maxUserInfoResponseBytes)

--- a/internal/proxy/external.go
+++ b/internal/proxy/external.go
@@ -25,20 +25,30 @@ func (h *Handler) handleExternal(ctx context.Context, w http.ResponseWriter, tar
 	}
 
 	if options.size != nil && strings.HasPrefix(contentType, "image/") && resp.StatusCode == http.StatusPartialContent && options.rangeHeader != "" {
-		resp.Body.Close()
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			return closeErr
+		}
 		resp, contentType, err = h.fetchAndValidateExternal(requestCtx, target, "")
 		if err != nil {
 			return err
 		}
 	}
 
-	defer resp.Body.Close()
-
+	var handlerErr error
 	if options.size != nil && strings.HasPrefix(contentType, "image/") {
-		return h.writeResizedImage(w, resp, contentType, *options.size, options.rangeHeader)
+		handlerErr = h.writeResizedImage(w, resp, contentType, *options.size, options.rangeHeader)
+	} else {
+		handlerErr = h.streamExternalResponse(w, resp, contentType)
 	}
 
-	return h.streamExternalResponse(w, resp, contentType)
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		if handlerErr != nil {
+			return errors.Join(handlerErr, closeErr)
+		}
+		return closeErr
+	}
+
+	return handlerErr
 }
 
 func (h *Handler) fetchAndValidateExternal(ctx context.Context, target *url.URL, rangeHeader string) (*http.Response, string, error) {
@@ -47,17 +57,16 @@ func (h *Handler) fetchAndValidateExternal(ctx context.Context, target *url.URL,
 		return nil, "", mapExternalError(err)
 	}
 	if err := checkExternalStatus(resp.StatusCode); err != nil {
-		resp.Body.Close()
-		return nil, "", err
+		return nil, "", closeResponseWithError(resp, err)
 	}
 	contentType, err := normalizeContentType(resp.Header.Get("Content-Type"))
 	if err != nil {
-		resp.Body.Close()
-		return nil, "", responseError{Status: http.StatusUnsupportedMediaType, Err: err}
+		respErr := responseError{Status: http.StatusUnsupportedMediaType, Err: err}
+		return nil, "", closeResponseWithError(resp, respErr)
 	}
 	if !isAllowedExternalContentType(contentType) {
-		resp.Body.Close()
-		return nil, "", responseError{Status: http.StatusUnsupportedMediaType}
+		respErr := responseError{Status: http.StatusUnsupportedMediaType}
+		return nil, "", closeResponseWithError(resp, respErr)
 	}
 	return resp, contentType, nil
 }
@@ -71,6 +80,16 @@ func (h *Handler) fetchExternal(ctx context.Context, target *url.URL, rangeHeade
 		req.Header.Set("Range", rangeHeader)
 	}
 	return h.httpClient.Do(req)
+}
+
+func closeResponseWithError(resp *http.Response, err error) error {
+	if closeErr := resp.Body.Close(); closeErr != nil {
+		if err == nil {
+			return closeErr
+		}
+		return errors.Join(err, closeErr)
+	}
+	return err
 }
 
 func checkExternalStatus(statusCode int) error {


### PR DESCRIPTION
## Summary
- add a reusable CORS handler with credentials enabled
- add a preflight test asserting Access-Control-Allow-Credentials
- handle response body close errors to satisfy lint

## Testing
- go test ./...
- golangci-lint run

## Issue
#5