### PR TITLE
fix(chart): split service-base includes into separate template files

### DIFF
--- a/charts/media-proxy/templates/deployment.yaml
+++ b/charts/media-proxy/templates/deployment.yaml
@@ -1,0 +1,2 @@
+{{- include "media-proxy.configureEnv" . -}}
+{{- include "service-base.deployment" . -}}

--- a/charts/media-proxy/templates/hpa.yaml
+++ b/charts/media-proxy/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.hpa" . -}}

--- a/charts/media-proxy/templates/ingress.yaml
+++ b/charts/media-proxy/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.ingress" . -}}

--- a/charts/media-proxy/templates/metrics.yaml
+++ b/charts/media-proxy/templates/metrics.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.metrics" . -}}

--- a/charts/media-proxy/templates/pdb.yaml
+++ b/charts/media-proxy/templates/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.pdb" . -}}

--- a/charts/media-proxy/templates/rbac.yaml
+++ b/charts/media-proxy/templates/rbac.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.rbac" . -}}

--- a/charts/media-proxy/templates/service-base.yaml
+++ b/charts/media-proxy/templates/service-base.yaml
@@ -1,9 +1,0 @@
-{{- include "media-proxy.configureEnv" . -}}
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}

--- a/charts/media-proxy/templates/service.yaml
+++ b/charts/media-proxy/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.service" . -}}

--- a/charts/media-proxy/templates/serviceaccount.yaml
+++ b/charts/media-proxy/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.serviceAccount" . -}}


### PR DESCRIPTION
## Problem

All 3 releases (v0.1.0, v0.1.1, v0.1.2) have failed `helm lint` with:

```
[ERROR] templates/service-base.yaml: unable to parse YAML:
  error converting YAML to JSON: yaml: line 10: did not find expected key
```

## Root Cause

The `templates/service-base.yaml` file contained **all 9 service-base subchart includes in a single template file**:

```yaml
{{- include "media-proxy.configureEnv" . -}}
{{- include "service-base.rbac" . -}}
{{- include "service-base.serviceAccount" . -}}
{{- include "service-base.service" . -}}
{{- include "service-base.deployment" . -}}
{{- include "service-base.hpa" . -}}
{{- include "service-base.ingress" . -}}
{{- include "service-base.pdb" . -}}
{{- include "service-base.metrics" . -}}
```

Each `service-base.*` include emits a complete Kubernetes resource manifest. When all are concatenated into a single template file output, Helm tries to parse them as **one YAML document**. The YAML parser hits the second resource's `apiVersion:` key (around line 10) and fails because it's unexpected within the first resource's mapping.

Helm processes each `.yaml` template file independently, so the fix is to put each include in its own file — exactly as done by all other charts consuming `service-base` (`files`, `chat-app`).

## Fix

- **Deleted** `templates/service-base.yaml`
- **Created** 8 individual template files:
  - `deployment.yaml` — includes `media-proxy.configureEnv` (mutates `.Values.env`) followed by `service-base.deployment`
  - `rbac.yaml` — `service-base.rbac`
  - `serviceaccount.yaml` — `service-base.serviceAccount`
  - `service.yaml` — `service-base.service`
  - `hpa.yaml` — `service-base.hpa`
  - `ingress.yaml` — `service-base.ingress`
  - `pdb.yaml` — `service-base.pdb`
  - `metrics.yaml` — `service-base.metrics`

This matches the template structure used by `agynio/files` and `agynio/chat-app`.