### PR TITLE
test(e2e): add media-proxy suite

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -4,6 +4,23 @@ vars:
   MEDIA_PROXY_NAMESPACE: platform
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
+deployments:
+  e2e-runner:
+    namespace: ${MEDIA_PROXY_NAMESPACE}
+    helm:
+      chart:
+        name: component-chart
+        repo: https://charts.devspace.sh
+      values:
+        containers:
+          - image: ${E2E_IMAGE}
+        labels:
+          app.kubernetes.io/name: media-proxy-e2e
+
+commands:
+  test:e2e: |-
+    devspace run-pipeline test:e2e $@
+
 functions:
   disable_argocd_sync: |-
     if kubectl get application media-proxy -n argocd >/dev/null 2>&1; then
@@ -111,6 +128,20 @@ pipelines:
         stop_dev media-proxy
       fi
 
+  test:e2e:
+    run: |-
+      create_deployments e2e-runner
+      start_dev e2e-runner &
+      sleep 5
+      exec_container \
+        --label-selector "app.kubernetes.io/name=media-proxy-e2e" \
+        -n ${MEDIA_PROXY_NAMESPACE} \
+        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
+      EXIT_CODE=$?
+      stop_dev e2e-runner
+      purge_deployments e2e-runner
+      exit $EXIT_CODE
+
 hooks:
   - name: restore-argocd-auto-sync
     events:
@@ -151,3 +182,15 @@ dev:
           lastLines: 200
     ports:
       - port: "8080"
+
+  e2e-runner:
+    namespace: ${MEDIA_PROXY_NAMESPACE}
+    labelSelector:
+      app.kubernetes.io/name: media-proxy-e2e
+    command: ["sleep", "infinity"]
+    workingDir: /opt/app/data
+    sync:
+      - path: ./:/opt/app/data
+        excludePaths:
+          - .git/
+          - .devspace/

--- a/test/e2e/external_test.go
+++ b/test/e2e/external_test.go
@@ -1,0 +1,170 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	externalImageURL = "https://www.w3.org/Graphics/PNG/nurbcup2si.png"
+	externalHTMLURL  = "https://www.w3.org/"
+)
+
+func TestExternalProxy_PublicImage(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentType := strings.TrimSpace(response.Header.Get("Content-Type"))
+	if contentType != "image/png" {
+		t.Fatalf("expected content-type image/png, got %q", contentType)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+}
+
+func TestExternalProxy_PublicImageWithResize(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 200), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+
+	image := decodeImage(t, body)
+	bounds := image.Bounds()
+	if bounds.Dx() > 200 || bounds.Dy() > 200 {
+		t.Fatalf("expected resized image within 200px, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestExternalProxy_NonImageURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalHTMLURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnsupportedMediaType {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 415, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_Unauthenticated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newClient().Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_InvalidToken(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL(externalImageURL, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient("invalid").Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestExternalProxy_MissingURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, mediaProxyURL+"/proxy", nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 400, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/test/e2e/file_test.go
+++ b/test/e2e/file_test.go
@@ -1,0 +1,185 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var testPNG = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89,
+	0x00, 0x00, 0x00, 0x0a, 0x49, 0x44, 0x41, 0x54,
+	0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05,
+	0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4,
+	0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+	0xae, 0x42, 0x60, 0x82,
+}
+
+func TestFileProxy_UploadAndProxy(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-upload.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentType := strings.TrimSpace(response.Header.Get("Content-Type"))
+	if contentType != "image/png" {
+		t.Fatalf("expected content-type image/png, got %q", contentType)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if !bytes.Equal(body, testPNG) {
+		t.Fatal("proxied file did not match uploaded content")
+	}
+}
+
+func TestFileProxy_UploadAndProxyWithResize(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-resize.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 100), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 200, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) == 0 {
+		t.Fatal("expected non-empty response body")
+	}
+
+	image := decodeImage(t, body)
+	bounds := image.Bounds()
+	if bounds.Dx() > 100 || bounds.Dy() > 100 {
+		t.Fatalf("expected resized image within 100px, got %dx%d", bounds.Dx(), bounds.Dy())
+	}
+}
+
+func TestFileProxy_NotFoundFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL("agyn://file/"+uuid.NewString(), 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 404, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}
+
+func TestFileProxy_RangeRequest(t *testing.T) {
+	uploadCtx, uploadCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	fileID := uploadTestFile(t, uploadCtx, "e2e-range.png", "image/png", testPNG)
+	uploadCancel()
+
+	proxyCtx, proxyCancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer proxyCancel()
+
+	request, err := http.NewRequestWithContext(proxyCtx, http.MethodGet, proxyURL("agyn://file/"+fileID, 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+	request.Header.Set("Range", "bytes=0-10")
+
+	response, err := newAuthenticatedClient(accessToken).Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusPartialContent {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 206, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	contentRange := strings.TrimSpace(response.Header.Get("Content-Range"))
+	if !strings.HasPrefix(contentRange, "bytes 0-10/") {
+		t.Fatalf("expected content-range header for bytes 0-10, got %q", contentRange)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if len(body) != 11 {
+		t.Fatalf("expected 11 bytes, got %d", len(body))
+	}
+}
+
+func TestFileProxy_Unauthenticated(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, proxyURL("agyn://file/"+uuid.NewString(), 0), nil)
+	if err != nil {
+		t.Fatalf("create request: %v", err)
+	}
+
+	response, err := newClient().Do(request)
+	if err != nil {
+		t.Fatalf("send request: %v", err)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusUnauthorized {
+		body, _ := io.ReadAll(response.Body)
+		t.Fatalf("expected status 401, got %d: %s", response.StatusCode, strings.TrimSpace(string(body)))
+	}
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -1,0 +1,308 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"image"
+	_ "image/png"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	filesv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/files/v1"
+	"github.com/agynio/media-proxy/internal/identity"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const (
+	mockAuthTokenURL     = "https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc/token"
+	mockAuthClientID     = "client_MU95KU3gHQf5Ir7p"
+	mockAuthClientSecret = "XPKka2i9uzISrKZ95zxli8sY51BK4eTJ"
+)
+
+var (
+	mediaProxyURL = envOrDefault("MEDIA_PROXY_URL", "http://media-proxy:8080")
+	filesAddress  = envOrDefault("FILES_ADDRESS", "files:50051")
+	gatewayURL    = envOrDefault("GATEWAY_URL", "http://gateway-gateway:8080")
+
+	accessToken      string
+	resolvedIdentity identity.ResolvedIdentity
+)
+
+type mePayload struct {
+	IdentityID   string `json:"identity_id"`
+	IdentityType string `json:"identity_type"`
+}
+
+func TestMain(m *testing.M) {
+	cleanup := &cleanupStack{}
+	ctx := context.Background()
+
+	if err := setupCredentials(ctx, cleanup); err != nil {
+		exitWithSetupError(cleanup, fmt.Errorf("setup credentials: %w", err))
+	}
+
+	exitCode := m.Run()
+	cleanup.Run()
+	os.Exit(exitCode)
+}
+
+type cleanupStack struct {
+	fns []func()
+}
+
+func (c *cleanupStack) Add(fn func()) {
+	c.fns = append(c.fns, fn)
+}
+
+func (c *cleanupStack) Run() {
+	for i := len(c.fns) - 1; i >= 0; i-- {
+		c.fns[i]()
+	}
+}
+
+func exitWithSetupError(cleanup *cleanupStack, err error) {
+	cleanup.Run()
+	fmt.Fprintf(os.Stderr, "e2e setup failed: %v\n", err)
+	os.Exit(1)
+}
+
+func setupCredentials(ctx context.Context, _ *cleanupStack) error {
+	requestCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	token, err := requestOIDCAccessToken(requestCtx)
+	if err != nil {
+		return err
+	}
+
+	meCtx, meCancel := context.WithTimeout(ctx, 15*time.Second)
+	defer meCancel()
+
+	identityInfo, err := fetchIdentity(meCtx, token)
+	if err != nil {
+		return err
+	}
+
+	accessToken = token
+	resolvedIdentity = identityInfo
+	return nil
+}
+
+func requestOIDCAccessToken(ctx context.Context) (string, error) {
+	form := url.Values{}
+	form.Set("grant_type", "password")
+	form.Set("username", "e2e-test-user")
+	form.Set("scope", "openid profile email")
+	form.Set("client_id", mockAuthClientID)
+	form.Set("client_secret", mockAuthClientSecret)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mockAuthTokenURL, strings.NewReader(form.Encode()))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	resp, err := newClient().Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("mockauth token request failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", err
+	}
+
+	token := strings.TrimSpace(payload.AccessToken)
+	if token == "" {
+		return "", fmt.Errorf("mockauth access_token missing")
+	}
+
+	return token, nil
+}
+
+func fetchIdentity(ctx context.Context, token string) (identity.ResolvedIdentity, error) {
+	client := newAuthenticatedClient(token)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, gatewayURL+"/me", nil)
+	if err != nil {
+		return identity.ResolvedIdentity{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return identity.ResolvedIdentity{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return identity.ResolvedIdentity{}, fmt.Errorf("me endpoint failed: status %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var payload mePayload
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return identity.ResolvedIdentity{}, err
+	}
+
+	identityID := strings.TrimSpace(payload.IdentityID)
+	if identityID == "" {
+		return identity.ResolvedIdentity{}, fmt.Errorf("identity_id missing")
+	}
+	identityType, err := identity.ParseIdentityType(payload.IdentityType)
+	if err != nil {
+		return identity.ResolvedIdentity{}, err
+	}
+
+	return identity.ResolvedIdentity{IdentityID: identityID, IdentityType: identityType}, nil
+}
+
+func proxyURL(rawURL string, size int) string {
+	params := url.Values{}
+	params.Set("url", strings.TrimSpace(rawURL))
+	if size > 0 {
+		params.Set("size", strconv.Itoa(size))
+	}
+
+	return mediaProxyURL + "/proxy?" + params.Encode()
+}
+
+func uploadTestFile(t *testing.T, ctx context.Context, filename, contentType string, data []byte) string {
+	t.Helper()
+
+	conn, err := grpc.NewClient(filesAddress, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("dial files: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+	})
+
+	resolved := resolvedIdentity
+	if resolved.IdentityID == "" {
+		t.Fatal("identity id missing")
+	}
+	if resolved.IdentityType == "" {
+		t.Fatal("identity type missing")
+	}
+	if len(data) == 0 {
+		t.Fatal("file data is empty")
+	}
+
+	uploadCtx := identity.AppendToOutgoingContext(identity.WithIdentity(ctx, resolved))
+	client := filesv1.NewFilesServiceClient(conn)
+	stream, err := client.UploadFile(uploadCtx)
+	if err != nil {
+		t.Fatalf("start upload: %v", err)
+	}
+
+	metadata := &filesv1.UploadFileRequest{
+		Payload: &filesv1.UploadFileRequest_Metadata{
+			Metadata: &filesv1.UploadFileMetadata{
+				Filename:    filename,
+				ContentType: contentType,
+				SizeBytes:   int64(len(data)),
+			},
+		},
+	}
+	if err := stream.Send(metadata); err != nil {
+		t.Fatalf("send metadata: %v", err)
+	}
+
+	chunkSplit := len(data) / 2
+	if chunkSplit == 0 {
+		chunkSplit = len(data)
+	}
+	if err := stream.Send(&filesv1.UploadFileRequest{
+		Payload: &filesv1.UploadFileRequest_Chunk{
+			Chunk: &filesv1.UploadFileChunk{Data: data[:chunkSplit]},
+		},
+	}); err != nil {
+		t.Fatalf("send chunk: %v", err)
+	}
+	if chunkSplit < len(data) {
+		if err := stream.Send(&filesv1.UploadFileRequest{
+			Payload: &filesv1.UploadFileRequest_Chunk{
+				Chunk: &filesv1.UploadFileChunk{Data: data[chunkSplit:]},
+			},
+		}); err != nil {
+			t.Fatalf("send chunk: %v", err)
+		}
+	}
+
+	resp, err := stream.CloseAndRecv()
+	if err != nil {
+		t.Fatalf("finish upload: %v", err)
+	}
+	if resp == nil || resp.GetFile() == nil {
+		t.Fatal("missing file in upload response")
+	}
+
+	fileID := strings.TrimSpace(resp.GetFile().GetId())
+	if fileID == "" {
+		t.Fatal("missing file id in upload response")
+	}
+
+	return fileID
+}
+
+func decodeImage(t *testing.T, data []byte) image.Image {
+	t.Helper()
+
+	img, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("decode image: %v", err)
+	}
+
+	return img
+}
+
+func newClient() *http.Client {
+	return &http.Client{Timeout: 15 * time.Second}
+}
+
+func newAuthenticatedClient(token string) *http.Client {
+	client := newClient()
+	client.Transport = bearerTransport{token: token, base: client.Transport}
+	return client
+}
+
+type bearerTransport struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (t bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.token)
+	return base.RoundTrip(clone)
+}
+
+func envOrDefault(key, fallback string) string {
+	if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+		return value
+	}
+	return fallback
+}


### PR DESCRIPTION
## Summary
- add media-proxy e2e tests for auth setup, external proxy, and file proxy flows
- add DevSpace e2e runner deployment + pipeline for in-cluster e2e runs

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml
- go vet ./...
- go test ./...
- golangci-lint run

Closes #8