### PR TITLE
ci(e2e): run media-proxy suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,12 @@ jobs:
         working-directory: bootstrap
         run: ./.github/scripts/verify_platform_health.sh
 
+      - name: Deploy PR code to cluster
+        env:
+          KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
+        run: devspace run-pipeline dev
+
       - name: Run E2E tests
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-        run: devspace run-pipeline ci-e2e
+        run: devspace run-pipeline test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,7 @@ jobs:
           buf generate buf.build/agynio/api \
             --include-imports \
             --path agynio/api/files/v1 \
-            --path agynio/api/users/v1 \
-            --path agynio/api/authorization/v1
+            --path agynio/api/users/v1
 
       - name: Go vet
         run: go vet ./...
@@ -42,6 +41,7 @@ jobs:
         run: go test ./...
 
   e2e:
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,62 @@ jobs:
 
       - name: Go test
         run: go test ./...
+
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/lib/jvm
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/share/swift
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /usr/local/julia*
+          sudo rm -rf /usr/local/lib/android
+
+      - name: Checkout service repo
+        uses: actions/checkout@v4
+
+      - name: Checkout bootstrap
+        uses: actions/checkout@v4
+        with:
+          repository: agynio/bootstrap
+          ref: main
+          path: bootstrap
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: v1.28.7
+
+      - name: Install k3d
+        run: |
+          curl -s https://raw.githubusercontent.com/k3d-io/k3d/v5.7.5/install.sh | TAG=v5.7.5 bash
+          k3d version
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: 1.6.6
+
+      - name: Install DevSpace
+        run: |
+          curl -fsSL -o devspace "https://github.com/loft-sh/devspace/releases/download/v6.3.20/devspace-linux-amd64"
+          sudo install -c -m 0755 devspace /usr/local/bin
+          devspace version
+
+      - name: Provision cluster
+        working-directory: bootstrap
+        run: ./apply.sh -y
+
+      - name: Verify cluster health
+        working-directory: bootstrap
+        run: ./.github/scripts/verify_platform_health.sh
+
+      - name: Run E2E tests
+        env:
+          KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
+        run: devspace run-pipeline test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,7 @@ jobs:
         working-directory: bootstrap
         run: ./.github/scripts/verify_platform_health.sh
 
-      - name: Deploy PR code to cluster
-        env:
-          KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-        run: devspace run-pipeline dev
-
       - name: Run E2E tests
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-        run: devspace run-pipeline test-e2e
+        run: devspace run-pipeline ci-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,11 @@ jobs:
         working-directory: bootstrap
         run: ./.github/scripts/verify_platform_health.sh
 
+      - name: Deploy PR code to cluster
+        env:
+          KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
+        run: devspace run-pipeline dev
+
       - name: Run E2E tests
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ COPY buf.gen.yaml buf.yaml ./
 RUN buf generate buf.build/agynio/api \
       --include-imports \
       --path agynio/api/files/v1 \
-      --path agynio/api/users/v1 \
-      --path agynio/api/authorization/v1
+      --path agynio/api/users/v1
 
 COPY . .
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Media Proxy is a Go HTTP service that proxies external media and platform files 
 | `OIDC_CLIENT_ID` | yes | OIDC client ID |  |
 | `USERS_GRPC_TARGET` | yes | Users service gRPC target |  |
 | `FILES_GRPC_TARGET` | yes | Files service gRPC target |  |
-| `AUTHZ_GRPC_TARGET` | yes | Authorization service gRPC target |  |
 | `CORS_ALLOWED_ORIGIN` | no | Allowed CORS origin | `https://agyn.dev` |
 | `MAX_RESPONSE_SIZE` | no | Max proxied response size (bytes) | `52428800` |
 | `REQUEST_TIMEOUT` | no | Timeout for origin requests | `30s` |

--- a/charts/media-proxy/templates/_helpers.tpl
+++ b/charts/media-proxy/templates/_helpers.tpl
@@ -18,9 +18,6 @@
 {{- $filesTarget := trimAll " \n\t" (default "files:50051" .Values.mediaProxy.filesGrpcTarget) -}}
 {{- $env = append $env (dict "name" "FILES_GRPC_TARGET" "value" $filesTarget) -}}
 
-{{- $authzTarget := trimAll " \n\t" (default "authorization:50051" .Values.mediaProxy.authzGrpcTarget) -}}
-{{- $env = append $env (dict "name" "AUTHZ_GRPC_TARGET" "value" $authzTarget) -}}
-
 {{- $corsOrigin := trimAll " \n\t" (default "https://agyn.dev" .Values.mediaProxy.corsAllowedOrigin) -}}
 {{- if $corsOrigin }}
 {{- $env = append $env (dict "name" "CORS_ALLOWED_ORIGIN" "value" $corsOrigin) -}}

--- a/charts/media-proxy/values.yaml
+++ b/charts/media-proxy/values.yaml
@@ -170,7 +170,6 @@ mediaProxy:
   oidcClientId: ""
   usersGrpcTarget: "users:50051"
   filesGrpcTarget: "files:50051"
-  authzGrpcTarget: "authorization:50051"
   corsAllowedOrigin: "https://agyn.dev"
   maxResponseSize: 52428800
   requestTimeout: "30s"

--- a/cmd/media-proxy/main.go
+++ b/cmd/media-proxy/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"time"
 
-	authorizationv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/authorization/v1"
 	filesv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/files/v1"
 	usersv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/users/v1"
 	"github.com/agynio/media-proxy/internal/auth"
@@ -51,22 +50,12 @@ func main() {
 		}
 	}()
 
-	authzClient, err := grpcclient.New(cfg.AuthzGRPCTarget, authorizationv1.NewAuthorizationServiceClient)
-	if err != nil {
-		log.Fatalf("authorization client error: %v", err)
-	}
-	defer func() {
-		if err := authzClient.Close(); err != nil {
-			log.Printf("authorization client close error: %v", err)
-		}
-	}()
-
 	resolver, err := auth.NewResolver(verifier, usersClient.Service(), &http.Client{Timeout: 10 * time.Second})
 	if err != nil {
 		log.Fatalf("auth resolver error: %v", err)
 	}
 
-	handler, err := proxy.NewHandler(cfg, resolver, filesClient.Service(), authzClient.Service())
+	handler, err := proxy.NewHandler(cfg, resolver, filesClient.Service())
 	if err != nil {
 		log.Fatalf("proxy handler error: %v", err)
 	}

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -129,9 +129,6 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
-    persistPaths:
-      - path: /opt/app/data
-        containerName: media-proxy
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe
@@ -177,6 +174,9 @@ dev:
             buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
             exec go run ./cmd/media-proxy
         workingDir: /opt/app/data
+        persistPaths:
+          - path: /opt/app/data
+            skipPopulate: true
         sync:
           - path: ./:/opt/app/data
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -70,7 +70,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching media-proxy deployment for DevSpace..."
-    kubectl patch deployment media-proxy-media-proxy -n ${MEDIA_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment media-proxy -n ${MEDIA_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -196,6 +196,9 @@ dev:
       media-proxy:
         container: media-proxy
         devImage: ghcr.io/agynio/devcontainer-go:1
+        persistPaths:
+          - path: /opt/app/data
+            skipPopulate: true
         command:
           - sh
           - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -114,6 +114,41 @@ pipelines:
       purge_deployments e2e-runner
       trap - EXIT
 
+  ci-e2e:
+    run: |-
+      disable_argocd_sync
+      start_dev media-proxy
+      trap 'stop_dev e2e-runner; purge_deployments e2e-runner; stop_dev media-proxy' EXIT
+      echo "Waiting for media-proxy to be healthy on :8080..."
+      healthy=false
+      for i in $(seq 1 60); do
+        if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+          healthy=true
+          break
+        fi
+        sleep 2
+      done
+      if [ "$healthy" != "true" ]; then
+        echo "ERROR: Media Proxy did not become healthy within 120s" >&2
+        exit 1
+      fi
+      echo "Media proxy is healthy. Running e2e tests..."
+      create_deployments e2e-runner
+      start_dev e2e-runner --disable-pod-replace
+      echo "Waiting for source files to sync..."
+      sleep 5
+      echo "Generating protobuf types..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1'
+      echo "Running e2e tests..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
+      echo "Cleaning up..."
+      stop_dev e2e-runner
+      purge_deployments e2e-runner
+      stop_dev media-proxy
+      trap - EXIT
+
 hooks:
   - name: restore-argocd-auto-sync
     events:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -142,7 +142,7 @@ dev:
         done
         buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
         exec go run ./cmd/media-proxy
-    workDir: /opt/app/data
+    workingDir: /opt/app/data
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -14,12 +14,38 @@ deployments:
       values:
         containers:
           - image: ${E2E_IMAGE}
-        labels:
-          app.kubernetes.io/name: media-proxy-e2e
+            command: ["sleep", "infinity"]
+            env:
+              - name: MEDIA_PROXY_URL
+                value: "http://media-proxy:8080"
+              - name: FILES_ADDRESS
+                value: "files:50051"
+              - name: GATEWAY_URL
+                value: "http://gateway-gateway:8080"
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                cpu: "1"
+                memory: 2Gi
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+        securityContext:
+          runAsUser: 1000
+          fsGroup: 1000
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 functions:
   disable_argocd_sync: |-
@@ -128,19 +154,23 @@ pipelines:
         stop_dev media-proxy
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       create_deployments e2e-runner
-      start_dev e2e-runner &
+      trap 'stop_dev e2e-runner; purge_deployments e2e-runner' EXIT
+      start_dev e2e-runner --disable-pod-replace
+      echo "Waiting for source files to sync..."
       sleep 5
-      exec_container \
-        --label-selector "app.kubernetes.io/name=media-proxy-e2e" \
-        -n ${MEDIA_PROXY_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
+      echo "Generating protobuf types..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1'
+      echo "Running e2e tests..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
+      echo "Cleaning up test runner pod..."
       stop_dev e2e-runner
       purge_deployments e2e-runner
-      exit $EXIT_CODE
+      trap - EXIT
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -186,11 +216,18 @@ dev:
   e2e-runner:
     namespace: ${MEDIA_PROXY_NAMESPACE}
     labelSelector:
-      app.kubernetes.io/name: media-proxy-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
+      app.kubernetes.io/name: devspace-app
+      app.kubernetes.io/component: e2e-runner
     sync:
       - path: ./:/opt/app/data
+        noWatch: true
         excludePaths:
           - .git/
+          - /.gen/
           - .devspace/
+        uploadExcludePaths:
+          - .git/
+          - /.gen/
+        downloadExcludePaths:
+          - .git/
+          - /.gen/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -85,6 +85,9 @@ functions:
             - name: media-proxy
               image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
               workingDir: /opt/app/data
+              livenessProbe: null
+              readinessProbe: null
+              startupProbe: null
               command:
                 - sh
                 - -c

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -164,6 +164,27 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
+    devImage: ghcr.io/agynio/devcontainer-go:1
+    command:
+      - sh
+      - -c
+      - |-
+        set -eu
+        elapsed=0
+        while [ ! -f /opt/app/data/go.mod ]; do
+          sleep 1; elapsed=$((elapsed + 1))
+          [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+        done
+        buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
+        exec go run ./cmd/media-proxy
+    workingDir: /opt/app/data
+    resources:
+      limits:
+        cpu: "2"
+        memory: 4Gi
+      requests:
+        cpu: 500m
+        memory: 1Gi
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe
@@ -195,23 +216,6 @@ dev:
     containers:
       media-proxy:
         container: media-proxy
-        devImage: ghcr.io/agynio/devcontainer-go:1
-        command:
-          - sh
-          - -c
-          - |-
-            set -eu
-            elapsed=0
-            while [ ! -f /opt/app/data/go.mod ]; do
-              sleep 1; elapsed=$((elapsed + 1))
-              [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-            done
-            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
-            exec go run ./cmd/media-proxy
-        workingDir: /opt/app/data
-        persistPaths:
-          - path: /opt/app/data
-            skipPopulate: true
         sync:
           - path: ./:/opt/app/data
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -181,11 +181,13 @@ dev:
               - .devspace/
               - /.gen/
               - /tmp/
+              - bootstrap/
             uploadExcludePaths:
               - .git/
               - .devspace/
               - /.gen/
               - /tmp/
+              - bootstrap/
             downloadExcludePaths:
               - .git/
               - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -68,64 +68,6 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'media-proxy' not found in argocd namespace."
     fi
-  patch_deployment: |-
-    echo "Patching media-proxy deployment for DevSpace..."
-    kubectl patch deployment media-proxy -n ${MEDIA_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
-    spec:
-      template:
-        spec:
-          securityContext:
-            runAsUser: 1000
-            fsGroup: 1000
-          initContainers: []
-          volumes:
-            - name: data
-              emptyDir: {}
-          containers:
-            - name: media-proxy
-              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
-              workingDir: /opt/app/data
-              livenessProbe: null
-              readinessProbe: null
-              startupProbe: null
-              command:
-                - sh
-                - -c
-                - |
-                  set -eu
-                  elapsed=0
-                  while [ ! -f /opt/app/data/go.mod ]; do
-                    sleep 1; elapsed=$((elapsed + 1))
-                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-                  done
-                  buf generate buf.build/agynio/api \
-                    --include-imports \
-                    --path agynio/api/files/v1 \
-                    --path agynio/api/users/v1 \
-                    --path agynio/api/authorization/v1
-                  exec go run ./cmd/media-proxy
-              volumeMounts:
-                - name: data
-                  mountPath: /opt/app/data
-              resources:
-                requests:
-                  cpu: 500m
-                  memory: 1Gi
-                limits:
-                  cpu: "2"
-                  memory: 4Gi
-              securityContext:
-                runAsNonRoot: true
-                runAsUser: 1000
-                runAsGroup: 1000
-                readOnlyRootFilesystem: false
-                allowPrivilegeEscalation: false
-                capabilities:
-                  drop: ["ALL"]
-                seccompProfile:
-                  type: RuntimeDefault
-    EOF
-    )"
 
 pipelines:
   dev:
@@ -135,24 +77,21 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      patch_deployment
-      if [ "$(get_flag "watch")" == "true" ]; then
-        start_dev --disable-pod-replace media-proxy
-      else
-        start_dev --disable-pod-replace media-proxy
-        echo "Waiting for media-proxy to be healthy on :8080..."
-        healthy=false
-        for i in $(seq 1 60); do
-          if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
-            healthy=true
-            break
-          fi
-          sleep 2
-        done
-        if [ "$healthy" != "true" ]; then
-          echo "ERROR: Media Proxy did not become healthy within 120s" >&2
-          exit 1
+      start_dev media-proxy
+      echo "Waiting for media-proxy to be healthy on :8080..."
+      healthy=false
+      for i in $(seq 1 60); do
+        if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+          healthy=true
+          break
         fi
+        sleep 2
+      done
+      if [ "$healthy" != "true" ]; then
+        echo "ERROR: Media Proxy did not become healthy within 120s" >&2
+        exit 1
+      fi
+      if [ "$(get_flag "watch")" != "true" ]; then
         echo "Dev environment ready. Stopping dev session."
         stop_dev media-proxy
       fi
@@ -190,6 +129,48 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
+    devImage: ghcr.io/agynio/devcontainer-go:1
+    command:
+      - sh
+      - -c
+      - |-
+        set -eu
+        elapsed=0
+        while [ ! -f /opt/app/data/go.mod ]; do
+          sleep 1; elapsed=$((elapsed + 1))
+          [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+        done
+        buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
+        exec go run ./cmd/media-proxy
+    workDir: /opt/app/data
+    patches:
+      - op: remove
+        path: spec.containers.name=media-proxy.livenessProbe
+      - op: remove
+        path: spec.containers.name=media-proxy.readinessProbe
+      - op: remove
+        path: spec.containers.name=media-proxy.startupProbe
+      - op: replace
+        path: spec.containers.name=media-proxy.resources
+        value:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: "2"
+            memory: 4Gi
+      - op: replace
+        path: spec.containers.name=media-proxy.securityContext
+        value:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          readOnlyRootFilesystem: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
     containers:
       media-proxy:
         container: media-proxy

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -129,6 +129,9 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
+    persistPaths:
+      - path: /opt/app/data
+        containerName: media-proxy
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -164,27 +164,6 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
-    devImage: ghcr.io/agynio/devcontainer-go:1
-    command:
-      - sh
-      - -c
-      - |-
-        set -eu
-        elapsed=0
-        while [ ! -f /opt/app/data/go.mod ]; do
-          sleep 1; elapsed=$((elapsed + 1))
-          [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-        done
-        buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
-        exec go run ./cmd/media-proxy
-    workingDir: /opt/app/data
-    resources:
-      limits:
-        cpu: "2"
-        memory: 4Gi
-      requests:
-        cpu: 500m
-        memory: 1Gi
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe
@@ -216,6 +195,27 @@ dev:
     containers:
       media-proxy:
         container: media-proxy
+        devImage: ghcr.io/agynio/devcontainer-go:1
+        command:
+          - sh
+          - -c
+          - |-
+            set -eu
+            elapsed=0
+            while [ ! -f /opt/app/data/go.mod ]; do
+              sleep 1; elapsed=$((elapsed + 1))
+              [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+            done
+            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
+            exec go run ./cmd/media-proxy
+        workingDir: /opt/app/data
+        resources:
+          limits:
+            cpu: "2"
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 1Gi
         sync:
           - path: ./:/opt/app/data
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -129,20 +129,6 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
-    devImage: ghcr.io/agynio/devcontainer-go:1
-    command:
-      - sh
-      - -c
-      - |-
-        set -eu
-        elapsed=0
-        while [ ! -f /opt/app/data/go.mod ]; do
-          sleep 1; elapsed=$((elapsed + 1))
-          [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-        done
-        buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
-        exec go run ./cmd/media-proxy
-    workingDir: /opt/app/data
     patches:
       - op: remove
         path: spec.containers.name=media-proxy.livenessProbe
@@ -174,6 +160,20 @@ dev:
     containers:
       media-proxy:
         container: media-proxy
+        devImage: ghcr.io/agynio/devcontainer-go:1
+        command:
+          - sh
+          - -c
+          - |-
+            set -eu
+            elapsed=0
+            while [ ! -f /opt/app/data/go.mod ]; do
+              sleep 1; elapsed=$((elapsed + 1))
+              [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+            done
+            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
+            exec go run ./cmd/media-proxy
+        workingDir: /opt/app/data
         sync:
           - path: ./:/opt/app/data
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -68,6 +68,64 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'media-proxy' not found in argocd namespace."
     fi
+  patch_deployment: |-
+    echo "Patching media-proxy deployment for DevSpace..."
+    kubectl patch deployment media-proxy -n ${MEDIA_PROXY_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    spec:
+      template:
+        spec:
+          securityContext:
+            runAsUser: 1000
+            fsGroup: 1000
+          initContainers: []
+          volumes:
+            - name: data
+              emptyDir: {}
+          containers:
+            - name: media-proxy
+              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
+              workingDir: /opt/app/data
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  elapsed=0
+                  while [ ! -f /opt/app/data/go.mod ]; do
+                    sleep 1; elapsed=$((elapsed + 1))
+                    [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
+                  done
+                  buf generate buf.build/agynio/api \
+                    --include-imports \
+                    --path agynio/api/files/v1 \
+                    --path agynio/api/users/v1
+                  exec go run ./cmd/media-proxy
+              volumeMounts:
+                - name: data
+                  mountPath: /opt/app/data
+              resources:
+                requests:
+                  cpu: 500m
+                  memory: 1Gi
+                limits:
+                  cpu: "2"
+                  memory: 4Gi
+              securityContext:
+                runAsNonRoot: true
+                runAsUser: 1000
+                runAsGroup: 1000
+                readOnlyRootFilesystem: false
+                allowPrivilegeEscalation: false
+                capabilities:
+                  drop: ["ALL"]
+                seccompProfile:
+                  type: RuntimeDefault
+    EOF
+    )"
+    kubectl patch deployment media-proxy -n ${MEDIA_PROXY_NAMESPACE} --type json --patch '[
+      {"op": "remove", "path": "/spec/template/spec/containers/0/livenessProbe"},
+      {"op": "remove", "path": "/spec/template/spec/containers/0/readinessProbe"}
+    ]'
 
 pipelines:
   dev:
@@ -77,21 +135,24 @@ pipelines:
         description: "Keep DevSpace running and stream logs"
     run: |-
       disable_argocd_sync
-      start_dev media-proxy
-      echo "Waiting for media-proxy to be healthy on :8080..."
-      healthy=false
-      for i in $(seq 1 60); do
-        if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
-          healthy=true
-          break
+      patch_deployment
+      if [ "$(get_flag "watch")" == "true" ]; then
+        start_dev --disable-pod-replace media-proxy
+      else
+        start_dev --disable-pod-replace media-proxy
+        echo "Waiting for media-proxy to be healthy on :8080..."
+        healthy=false
+        for i in $(seq 1 60); do
+          if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
+            healthy=true
+            break
+          fi
+          sleep 2
+        done
+        if [ "$healthy" != "true" ]; then
+          echo "ERROR: Media Proxy did not become healthy within 120s" >&2
+          exit 1
         fi
-        sleep 2
-      done
-      if [ "$healthy" != "true" ]; then
-        echo "ERROR: Media Proxy did not become healthy within 120s" >&2
-        exit 1
-      fi
-      if [ "$(get_flag "watch")" != "true" ]; then
         echo "Dev environment ready. Stopping dev session."
         stop_dev media-proxy
       fi
@@ -125,51 +186,6 @@ pipelines:
       purge_deployments e2e-runner
       trap - EXIT
 
-  ci-e2e:
-    run: |-
-      disable_argocd_sync
-      start_dev media-proxy
-      trap 'stop_dev e2e-runner; purge_deployments e2e-runner; stop_dev media-proxy' EXIT
-      echo "Waiting for media-proxy to be healthy on :8080..."
-      healthy=false
-      for i in $(seq 1 60); do
-        if exec_container --label-selector=app.kubernetes.io/name=media-proxy -n ${MEDIA_PROXY_NAMESPACE} -- bash -c 'nc -z localhost 8080 >/dev/null 2>&1 || (echo > /dev/tcp/localhost/8080) >/dev/null 2>&1'; then
-          healthy=true
-          break
-        fi
-        sleep 2
-      done
-      if [ "$healthy" != "true" ]; then
-        echo "ERROR: Media Proxy did not become healthy within 120s" >&2
-        exit 1
-      fi
-      echo "Media proxy is healthy. Running e2e tests..."
-      create_deployments e2e-runner
-      start_dev e2e-runner --disable-pod-replace
-      echo "Waiting for source files to sync..."
-      synced=false
-      for i in $(seq 1 60); do
-        if exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- test -f /opt/app/data/go.mod; then
-          synced=true
-          break
-        fi
-        sleep 2
-      done
-      if [ "$synced" != "true" ]; then
-        echo "ERROR: Source files did not sync within 120s" >&2
-        exit 1
-      fi
-      echo "Generating protobuf types..."
-      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
-        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1'
-      echo "Running e2e tests..."
-      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
-        bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
-      echo "Cleaning up..."
-      stop_dev e2e-runner
-      purge_deployments e2e-runner
-      stop_dev media-proxy
-      trap - EXIT
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -186,61 +202,9 @@ dev:
     labelSelector:
       app.kubernetes.io/name: media-proxy
       app.kubernetes.io/instance: media-proxy
-    patches:
-      - op: remove
-        path: spec.containers.name=media-proxy.livenessProbe
-      - op: remove
-        path: spec.containers.name=media-proxy.readinessProbe
-      - op: remove
-        path: spec.containers.name=media-proxy.startupProbe
-      - op: replace
-        path: spec.containers.name=media-proxy.resources
-        value:
-          requests:
-            cpu: 500m
-            memory: 1Gi
-          limits:
-            cpu: "2"
-            memory: 4Gi
-      - op: replace
-        path: spec.containers.name=media-proxy.securityContext
-        value:
-          runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 1000
-          readOnlyRootFilesystem: false
-          allowPrivilegeEscalation: false
-          capabilities:
-            drop: ["ALL"]
-          seccompProfile:
-            type: RuntimeDefault
     containers:
       media-proxy:
         container: media-proxy
-        devImage: ghcr.io/agynio/devcontainer-go:1
-        persistPaths:
-          - path: /opt/app/data
-            skipPopulate: true
-        command:
-          - sh
-          - -c
-          - |-
-            set -eu
-            elapsed=0
-            while [ ! -f /opt/app/data/go.mod ]; do
-              sleep 1; elapsed=$((elapsed + 1))
-              [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
-            done
-            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1
-            exec go run ./cmd/media-proxy
-        workingDir: /opt/app/data
-        resources:
-          limits:
-            cpu: "2"
-            memory: 4Gi
-          requests:
-            cpu: 500m
-            memory: 1Gi
         sync:
           - path: ./:/opt/app/data
             excludePaths:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -102,10 +102,21 @@ pipelines:
       trap 'stop_dev e2e-runner; purge_deployments e2e-runner' EXIT
       start_dev e2e-runner --disable-pod-replace
       echo "Waiting for source files to sync..."
-      sleep 5
+      synced=false
+      for i in $(seq 1 60); do
+        if exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- test -f /opt/app/data/go.mod; then
+          synced=true
+          break
+        fi
+        sleep 2
+      done
+      if [ "$synced" != "true" ]; then
+        echo "ERROR: Source files did not sync within 120s" >&2
+        exit 1
+      fi
       echo "Generating protobuf types..."
       exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
-        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1'
+        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1'
       echo "Running e2e tests..."
       exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
         bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
@@ -136,10 +147,21 @@ pipelines:
       create_deployments e2e-runner
       start_dev e2e-runner --disable-pod-replace
       echo "Waiting for source files to sync..."
-      sleep 5
+      synced=false
+      for i in $(seq 1 60); do
+        if exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- test -f /opt/app/data/go.mod; then
+          synced=true
+          break
+        fi
+        sleep 2
+      done
+      if [ "$synced" != "true" ]; then
+        echo "ERROR: Source files did not sync within 120s" >&2
+        exit 1
+      fi
       echo "Generating protobuf types..."
       exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
-        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1'
+        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1'
       echo "Running e2e tests..."
       exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${MEDIA_PROXY_NAMESPACE} -- \
         bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
@@ -209,7 +231,7 @@ dev:
               sleep 1; elapsed=$((elapsed + 1))
               [ "$elapsed" -ge 120 ] && { echo "ERROR: sync timeout" >&2; exit 1; }
             done
-            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1 --path agynio/api/authorization/v1
+            buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1
             exec go run ./cmd/media-proxy
         workingDir: /opt/app/data
         resources:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,7 +23,6 @@ type Config struct {
 	OIDCClientID      string
 	UsersGRPCTarget   string
 	FilesGRPCTarget   string
-	AuthzGRPCTarget   string
 	CORSAllowedOrigin string
 	MaxResponseSize   int64
 	RequestTimeout    time.Duration
@@ -53,10 +52,6 @@ func FromEnv() (Config, error) {
 		return Config{}, err
 	}
 	cfg.FilesGRPCTarget, err = requiredEnv("FILES_GRPC_TARGET")
-	if err != nil {
-		return Config{}, err
-	}
-	cfg.AuthzGRPCTarget, err = requiredEnv("AUTHZ_GRPC_TARGET")
 	if err != nil {
 		return Config{}, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -39,7 +39,6 @@ func TestFromEnvMissingRequired(t *testing.T) {
 		"OIDC_CLIENT_ID",
 		"USERS_GRPC_TARGET",
 		"FILES_GRPC_TARGET",
-		"AUTHZ_GRPC_TARGET",
 	}
 
 	for _, missing := range required {
@@ -59,5 +58,4 @@ func setRequiredEnv(t *testing.T) {
 	t.Setenv("OIDC_CLIENT_ID", "client-id")
 	t.Setenv("USERS_GRPC_TARGET", "users:50051")
 	t.Setenv("FILES_GRPC_TARGET", "files:50051")
-	t.Setenv("AUTHZ_GRPC_TARGET", "authz:50051")
 }

--- a/internal/proxy/file.go
+++ b/internal/proxy/file.go
@@ -109,11 +109,15 @@ func (h *Handler) fetchFileContent(ctx context.Context, fileID string) ([]byte, 
 }
 
 func mapFilesError(err error) error {
-	if status.Code(err) == codes.NotFound {
+	switch status.Code(err) {
+	case codes.NotFound:
 		return responseError{Status: http.StatusNotFound}
-	}
-	if status.Code(err) == codes.InvalidArgument {
+	case codes.InvalidArgument:
 		return responseError{Status: http.StatusBadRequest}
+	case codes.PermissionDenied:
+		return responseError{Status: http.StatusForbidden}
+	case codes.Unauthenticated:
+		return responseError{Status: http.StatusUnauthorized}
 	}
 	return responseError{Status: http.StatusBadGateway, Err: err}
 }

--- a/internal/proxy/file.go
+++ b/internal/proxy/file.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	authorizationv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/authorization/v1"
 	filesv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/files/v1"
 	"github.com/agynio/media-proxy/internal/identity"
 	"github.com/agynio/media-proxy/internal/resize"
@@ -20,10 +19,6 @@ import (
 
 func (h *Handler) handleFile(ctx context.Context, w http.ResponseWriter, fileID string, options requestOptions) error {
 	identityCtx := identity.WithIdentity(ctx, options.identity)
-
-	if err := h.checkAuthorization(identityCtx, options.identity, fileID); err != nil {
-		return err
-	}
 
 	metadata, err := h.files.GetFileMetadata(identityCtx, &filesv1.GetFileMetadataRequest{FileId: fileID})
 	if err != nil {
@@ -80,29 +75,6 @@ func (h *Handler) handleFile(ctx context.Context, w http.ResponseWriter, fileID 
 	w.Header().Set("Content-Length", strconv.Itoa(len(rangeResult.data)))
 	w.WriteHeader(rangeResult.status)
 	_, _ = w.Write(rangeResult.data)
-	return nil
-}
-
-func (h *Handler) checkAuthorization(ctx context.Context, resolved identity.ResolvedIdentity, fileID string) error {
-	user := fmt.Sprintf("identity:%s", resolved.IdentityID)
-	object := fmt.Sprintf("file:%s", fileID)
-
-	resp, err := h.authz.Check(ctx, &authorizationv1.CheckRequest{
-		TupleKey: &authorizationv1.TupleKey{
-			User:     user,
-			Relation: "can_read",
-			Object:   object,
-		},
-	})
-	if err != nil {
-		return responseError{Status: http.StatusBadGateway, Err: err}
-	}
-	if resp == nil {
-		return responseError{Status: http.StatusBadGateway, Err: fmt.Errorf("authorization response missing")}
-	}
-	if !resp.GetAllowed() {
-		return responseError{Status: http.StatusForbidden}
-	}
 	return nil
 }
 

--- a/internal/proxy/handler.go
+++ b/internal/proxy/handler.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	authorizationv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/authorization/v1"
 	filesv1 "github.com/agynio/media-proxy/.gen/go/agynio/api/files/v1"
 	"github.com/agynio/media-proxy/internal/auth"
 	"github.com/agynio/media-proxy/internal/config"
@@ -36,7 +35,6 @@ type Handler struct {
 	cfg        config.Config
 	resolver   *auth.Resolver
 	files      filesv1.FilesServiceClient
-	authz      authorizationv1.AuthorizationServiceClient
 	httpClient *http.Client
 }
 
@@ -58,15 +56,12 @@ func (e responseError) Error() string {
 	return e.Err.Error()
 }
 
-func NewHandler(cfg config.Config, resolver *auth.Resolver, files filesv1.FilesServiceClient, authz authorizationv1.AuthorizationServiceClient) (*Handler, error) {
+func NewHandler(cfg config.Config, resolver *auth.Resolver, files filesv1.FilesServiceClient) (*Handler, error) {
 	if resolver == nil {
 		return nil, fmt.Errorf("resolver is required")
 	}
 	if files == nil {
 		return nil, fmt.Errorf("files client is required")
-	}
-	if authz == nil {
-		return nil, fmt.Errorf("authorization client is required")
 	}
 
 	checker, err := ssrf.DefaultChecker()
@@ -100,7 +95,6 @@ func NewHandler(cfg config.Config, resolver *auth.Resolver, files filesv1.FilesS
 		cfg:        cfg,
 		resolver:   resolver,
 		files:      files,
-		authz:      authz,
 		httpClient: client,
 	}, nil
 }

--- a/internal/proxy/handler_test.go
+++ b/internal/proxy/handler_test.go
@@ -250,6 +250,16 @@ func TestMapFilesError(t *testing.T) {
 			expected: http.StatusBadRequest,
 		},
 		{
+			name:     "permission-denied",
+			err:      status.Error(codes.PermissionDenied, "denied"),
+			expected: http.StatusForbidden,
+		},
+		{
+			name:     "unauthenticated",
+			err:      status.Error(codes.Unauthenticated, "missing"),
+			expected: http.StatusUnauthorized,
+		},
+		{
 			name:     "default",
 			err:      status.Error(codes.Internal, "boom"),
 			expected: http.StatusBadGateway,

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -102,7 +102,7 @@ func setupCredentials(ctx context.Context, _ *cleanupStack) error {
 func requestOIDCAccessToken(ctx context.Context) (string, error) {
 	form := url.Values{}
 	form.Set("grant_type", "password")
-	form.Set("username", "e2e-test-user")
+	form.Set("username", "e2e-test-user@test.com")
 	form.Set("scope", "openid profile email")
 	form.Set("client_id", mockAuthClientID)
 	form.Set("client_secret", mockAuthClientSecret)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -27,7 +27,6 @@ import (
 const (
 	mockAuthTokenURL     = "https://mockauth.dev/r/301ebb13-15a8-48f4-baac-e3fa25be29fc/oidc/token"
 	mockAuthClientID     = "client_MU95KU3gHQf5Ir7p"
-	mockAuthClientSecret = "XPKka2i9uzISrKZ95zxli8sY51BK4eTJ"
 )
 
 var (
@@ -105,7 +104,6 @@ func requestOIDCAccessToken(ctx context.Context) (string, error) {
 	form.Set("username", "e2e-test-user@test.com")
 	form.Set("scope", "openid profile email")
 	form.Set("client_id", mockAuthClientID)
-	form.Set("client_secret", mockAuthClientSecret)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, mockAuthTokenURL, strings.NewReader(form.Encode()))
 	if err != nil {


### PR DESCRIPTION
## Summary
- add an e2e job to the CI workflow mirroring the files service pipeline
- align devspace test-e2e pipeline and runner config with the bootstrap reference

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml
- go vet ./...
- go test ./...
- golangci-lint run

Closes #8