### PR TITLE
ci: align e2e workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: e2e-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
@@ -13,14 +16,12 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    permissions:
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@adf1dc4453de5934a9bae8c0f03f7b417e472d79
+        uses: agynio/bootstrap/.github/actions/provision@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -36,4 +36,4 @@ jobs:
 
       - name: Restore ArgoCD auto-sync
         if: always()
-        run: devspace run-pipeline restore-argocd
+        run: RESTORE_ARGOCD_IN_CI=true devspace run-pipeline restore-argocd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,3 +33,7 @@ jobs:
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
           service: media_proxy
+
+      - name: Restore ArgoCD auto-sync
+        if: always()
+        run: devspace run-pipeline restore-argocd

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,7 +32,8 @@ jobs:
       - name: Run E2E tests
         uses: agynio/e2e/.github/actions/run-tests@main
         with:
-          service: media_proxy
+          tag: svc_media_proxy
+          include_smoke: "false"
 
       - name: Restore ArgoCD auto-sync
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -34,6 +34,8 @@ jobs:
         with:
           tag: svc_media_proxy
           include_smoke: "false"
+        env:
+          E2E_SUITES: go-core
 
       - name: Restore ArgoCD auto-sync
         if: always()

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -15,6 +15,10 @@ functions:
       echo "WARNING: ArgoCD Application 'media-proxy' not found in argocd namespace."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
+    if [ -n "${CI:-}" ] && [ "${RESTORE_ARGOCD_IN_CI:-}" != "true" ]; then
+      echo "Skipping ArgoCD auto-sync restore in CI."
+      exit 0
+    fi
     if kubectl get application media-proxy -n argocd >/dev/null 2>&1; then
       echo "Re-enabling ArgoCD auto-sync for media-proxy..."
       kubectl patch application media-proxy -n argocd \

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -15,10 +15,6 @@ functions:
       echo "WARNING: ArgoCD Application 'media-proxy' not found in argocd namespace."
     fi
   restore_argocd_sync: &restore_argocd_sync |-
-    if [ -n "${CI:-}" ]; then
-      echo "Skipping ArgoCD auto-sync restore in CI."
-      exit 0
-    fi
     if kubectl get application media-proxy -n argocd >/dev/null 2>&1; then
       echo "Re-enabling ArgoCD auto-sync for media-proxy..."
       kubectl patch application media-proxy -n argocd \
@@ -118,6 +114,10 @@ pipelines:
         echo "Dev environment ready. Stopping dev session."
         stop_dev media-proxy
       fi
+
+  restore-argocd:
+    run: |-
+      restore_argocd_sync
 
 
 hooks:


### PR DESCRIPTION
## Summary
- Aligns E2E workflow with centralized architecture: provision via `agynio/bootstrap/.github/actions/provision@main`, deploy media-proxy from source with `devspace dev`, then run `agynio/e2e/.github/actions/run-tests@main`.
- Replaces the pinned bootstrap action commit with `@main`.
- Adds read-only workflow permissions to CI/E2E.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #14

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `buf generate buf.build/agynio/api --include-imports --path agynio/api/files/v1 --path agynio/api/users/v1` — passed.
- `go vet ./...` — passed with no errors.
- `go build ./...` — passed.
- `go test ./...` — 59 passed, 0 failed, 0 skipped.