### PR TITLE
feat(auth): validate OIDC audience

### DIFF
--- a/charts/media-proxy/Chart.yaml
+++ b/charts/media-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: media-proxy
 description: Helm chart for deploying the agyn media proxy service.
 type: application
-version: 0.1.0
-appVersion: 0.1.0
+version: 0.1.7
+appVersion: 0.1.7
 home: https://github.com/agynio/media-proxy
 sources:
   - https://github.com/agynio/media-proxy

--- a/charts/media-proxy/templates/_helpers.tpl
+++ b/charts/media-proxy/templates/_helpers.tpl
@@ -12,6 +12,9 @@
 {{- $clientId := trimAll " \n\t" (default "" .Values.mediaProxy.oidcClientId) -}}
 {{- $env = append $env (dict "name" "OIDC_CLIENT_ID" "value" $clientId) -}}
 
+{{- $audience := trimAll " \n\t" (default "" .Values.mediaProxy.oidcAudience) -}}
+{{- $env = append $env (dict "name" "OIDC_AUDIENCE" "value" $audience) -}}
+
 {{- $usersTarget := trimAll " \n\t" (default "users:50051" .Values.mediaProxy.usersGrpcTarget) -}}
 {{- $env = append $env (dict "name" "USERS_GRPC_TARGET" "value" $usersTarget) -}}
 

--- a/charts/media-proxy/values.yaml
+++ b/charts/media-proxy/values.yaml
@@ -168,6 +168,7 @@ mediaProxy:
   listenAddr: ":8080"
   oidcIssuerUrl: ""
   oidcClientId: ""
+  oidcAudience: ""
   usersGrpcTarget: "users:50051"
   filesGrpcTarget: "files:50051"
   corsAllowedOrigin: "https://agyn.dev"

--- a/cmd/media-proxy/main.go
+++ b/cmd/media-proxy/main.go
@@ -27,7 +27,7 @@ func main() {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 
-		verifier, err := auth.NewVerifier(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID)
+		verifier, err := auth.NewVerifierWithAudience(ctx, cfg.OIDCIssuerURL, cfg.OIDCClientID, cfg.OIDCAudience)
 		if err != nil {
 			log.Fatalf("oidc verifier error: %v", err)
 		}

--- a/internal/auth/verifier.go
+++ b/internal/auth/verifier.go
@@ -19,6 +19,7 @@ type Claims struct {
 type Verifier struct {
 	issuer            string
 	clientID          string
+	audience          string
 	keySet            oidc.KeySet
 	userinfoEndpoint  string
 	supportedSignAlgs []string // nil accepts any JWKS alg (matches gateway verifier).
@@ -26,6 +27,10 @@ type Verifier struct {
 }
 
 func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error) {
+	return NewVerifierWithAudience(ctx, issuer, clientID, "")
+}
+
+func NewVerifierWithAudience(ctx context.Context, issuer, clientID, audience string) (*Verifier, error) {
 	trimmedIssuer := strings.TrimSpace(issuer)
 	if trimmedIssuer == "" {
 		return nil, fmt.Errorf("issuer is required")
@@ -34,6 +39,7 @@ func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error
 	if trimmedClientID == "" {
 		return nil, fmt.Errorf("client id is required")
 	}
+	trimmedAudience := strings.TrimSpace(audience)
 
 	discovery, err := client.Discover(ctx, trimmedIssuer, httphelper.DefaultHTTPClient)
 	if err != nil {
@@ -48,6 +54,7 @@ func NewVerifier(ctx context.Context, issuer, clientID string) (*Verifier, error
 	return &Verifier{
 		issuer:           trimmedIssuer,
 		clientID:         trimmedClientID,
+		audience:         trimmedAudience,
 		keySet:           rp.NewRemoteKeySet(httphelper.DefaultHTTPClient, jwksURI),
 		userinfoEndpoint: userinfoEndpoint,
 		clockSkew:        time.Second,
@@ -86,6 +93,9 @@ func (v *Verifier) Verify(ctx context.Context, accessToken string) (Claims, erro
 	if err := oidc.CheckExpiration(&parsed, v.clockSkew); err != nil {
 		return Claims{}, err
 	}
+	if v.audience != "" && !containsAudience(parsed.Audience, v.audience) {
+		return Claims{}, fmt.Errorf("audience %q is required", v.audience)
+	}
 
 	subject := strings.TrimSpace(parsed.Subject)
 	if subject == "" {
@@ -95,4 +105,13 @@ func (v *Verifier) Verify(ctx context.Context, accessToken string) (Claims, erro
 	return Claims{
 		Subject: subject,
 	}, nil
+}
+
+func containsAudience(audiences oidc.Audience, required string) bool {
+	for _, audience := range audiences {
+		if audience == required {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,7 @@ type Config struct {
 	ListenAddr        string
 	OIDCIssuerURL     string
 	OIDCClientID      string
+	OIDCAudience      string
 	UsersGRPCTarget   string
 	FilesGRPCTarget   string
 	CORSAllowedOrigin string
@@ -40,6 +41,7 @@ func FromEnv() (Config, error) {
 
 	cfg.OIDCIssuerURL = strings.TrimSpace(os.Getenv("OIDC_ISSUER_URL"))
 	cfg.OIDCClientID = strings.TrimSpace(os.Getenv("OIDC_CLIENT_ID"))
+	cfg.OIDCAudience = strings.TrimSpace(os.Getenv("OIDC_AUDIENCE"))
 	if cfg.OIDCIssuerURL != "" && cfg.OIDCClientID == "" {
 		return Config{}, fmt.Errorf("OIDC_CLIENT_ID must be set when OIDC_ISSUER_URL is set")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ import (
 
 func TestFromEnvDefaults(t *testing.T) {
 	setRequiredEnv(t)
+	t.Setenv("OIDC_AUDIENCE", "https://api.example.com")
 
 	cfg, err := FromEnv()
 	if err != nil {
@@ -30,6 +31,9 @@ func TestFromEnvDefaults(t *testing.T) {
 	}
 	if cfg.MaxImageSize != 4096 {
 		t.Fatalf("unexpected max image size: %d", cfg.MaxImageSize)
+	}
+	if cfg.OIDCAudience != "https://api.example.com" {
+		t.Fatalf("unexpected oidc audience: %s", cfg.OIDCAudience)
 	}
 }
 


### PR DESCRIPTION
## Summary

Supports agynio/infrastructure#22 and agynio/infrastructure#23 by making the Logto API resource indicator functional instead of an inert chart value.

This PR wires the OIDC resource/audience through this repository's runtime/chart contract so the platform chart can pass `https://agyn.cloud` from the Logto workspace outputs.

## Validation

See the parent infrastructure PR for the full cross-repository validation summary.
